### PR TITLE
Support tensorflow by adding patchelf

### DIFF
--- a/recipe/bazel_toolchain/cc_toolchain_config.bzl
+++ b/recipe/bazel_toolchain/cc_toolchain_config.bzl
@@ -29,6 +29,10 @@ def _impl(ctx):
             path = "${CONDA_PREFIX}/bin/${AR}",
         ),
         tool_path(
+            name = "patchelf",
+            path = "${CONDA_PREFIX}/bin/patchelf",
+        ),
+        tool_path(
             name = "cpp",
             path = "/usr/bin/cpp",
         ),

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@ package:
   version: {{ version }}
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win or s390x]
 
 requirements:


### PR DESCRIPTION
**Destination channel:** defaults

### Explanation of changes:

- copies the custom_toolchain from the branch of [this PR](https://github.com/AnacondaRecipes/tensorflow-feedstock/pull/1). Just adds support for patchelf, rather than requiring that patchelf must be used
