### PR TITLE
Fix execution of crosstool_wrapper_is_not_gcc script

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@ package:
   version: {{ version }}
 
 build:
-  number: 1
+  number: 2
   skip: true  # [win or s390x]
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,6 +15,8 @@ requirements:
     # This can be used without bazel from conda-forge,
     # e.g. when bootstrapping bazel itself.
     - bazel >=6
+    # the crosstool_wrapper_is_not_gcc script uses pipes, which was removed in python 3.13
+    - python <3.13
 
 test:
   requires:


### PR DESCRIPTION
**Destination channel:** defaults

### Explanation of changes:

- `pipes` was dropped from python 3.13, and since our release of python 3.13 this is broken for compiling cuda feedstocks.
