### PR TITLE
Fix for python 3.13

### DIFF
--- a/recipe/bazel_toolchain/crosstool_wrapper_driver_is_not_gcc
+++ b/recipe/bazel_toolchain/crosstool_wrapper_driver_is_not_gcc
@@ -37,7 +37,7 @@ import os
 import subprocess
 import re
 import sys
-import pipes
+import shlex
 
 # Template values set by cuda_autoconf.
 CPU_COMPILER = "${GCC_COMPILER_PATH}"
@@ -265,7 +265,7 @@ def main():
 
     if args.x and args.x[0] == 'cuda':
         if args.cuda_log: Log('-x cuda')
-        leftover = [pipes.quote(s) for s in leftover]
+        leftover = [shlex.quote(s) for s in leftover]
         if args.cuda_log: Log('using nvcc')
         return InvokeNvcc(leftover, log=args.cuda_log)
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@ package:
   version: {{ version }}
 
 build:
-  number: 2
+  number: 3
   skip: true  # [win or s390x]
 
 requirements:
@@ -15,8 +15,6 @@ requirements:
     # This can be used without bazel from conda-forge,
     # e.g. when bootstrapping bazel itself.
     - bazel >=6
-    # the crosstool_wrapper_is_not_gcc script uses pipes, which was removed in python 3.13
-    - python <3.13
 
 test:
   requires:


### PR DESCRIPTION
bazel-toolchain

**Destination channel:** defaults

### Links

- [PKG-5974](https://anaconda.atlassian.net/browse/PKG-5974) 

### Explanation of changes:

- Gets rid of the use of `pipes` that was removed from python 3.13


On a CUDA machine, you can run this to reproduce:
```bash
export ANACONDA_ROCKET_ENABLE_PY313=yes &&  conda build  --python=3.13 jaxlib-feedstock/
```

You will get:
```
/root/.cache/bazel/_bazel_root/6454abfbaea688066c5fd2118cb122e9/execroot/__main__/bazel_toolchain/crosstool_wrapper_driver_is_not_gcc:213: SyntaxWarning: invalid escape sequence '\.'
  re.search('\.cpp$|\.cc$|\.c$|\.cxx$|\.C$', f)]
Traceback (most recent call last):
  File "/root/.cache/bazel/_bazel_root/6454abfbaea688066c5fd2118cb122e9/execroot/__main__/bazel_toolchain/crosstool_wrapper_driver_is_not_gcc", line 40, in <module>
    import pipes
ModuleNotFoundError: No module named 'pipes'
Target //jaxlib/tools:build_wheel failed to build
INFO: Elapsed time: 29.413s, Critical Path: 0.22s
INFO: 51 processes: 43 internal, 8 local.
FAILED: Build did NOT complete successfully
ERROR: Build failed. Not running target

     _   _  __  __
    | | / \ \ \/ /
 _  | |/ _ \ \  /
| |_| / ___ \/  \
 \___/_/   \/_/\_\


```


You can verify the fix by:
```bash
export ANACONDA_ROCKET_ENABLE_PY313=yes &&  conda build --croot="../bazel-toolcahin" -c https://staging.continuum.io/prefect/fs/bazel-toolchain-feedstock/pr5/d265626 --python=3.13 jaxlib-feedstock 
```


[PKG-5974]: https://anaconda.atlassian.net/browse/PKG-5974?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ