### PR TITLE
Pkg 7396

### DIFF
--- a/recipe/bazel_toolchain/crosstool_wrapper_driver_is_not_gcc
+++ b/recipe/bazel_toolchain/crosstool_wrapper_driver_is_not_gcc
@@ -210,7 +210,7 @@ def InvokeNvcc(argv, log=False):
     # Unfortunately, there are other options that have -c prefix too.
     # So allowing only those look like C/C++ files.
     src_files = [f for f in src_files if
-                 re.search('\.cpp$|\.cc$|\.c$|\.cxx$|\.C$', f)]
+                 re.search(r'\.cpp$|\.cc$|\.c$|\.cxx$|\.C$', f)]
     srcs = ' '.join(src_files)
     out = ' -o ' + out_file[0]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@ package:
   version: {{ version }}
 
 build:
-  number: 3
+  number: 4
   skip: true  # [win or s390x]
 
 requirements:


### PR DESCRIPTION
- Relevant dependency PRs:
  - https://github.com/AnacondaRecipes/protobuf-feedstock/pulls is using this fixed version from a [staging channel](https://anaconda.org/libprotobuf-5.29.3/bazel-toolchain)

### Explanation of changes:

Prevent log spamming on linux-64:
```
bazel_toolchain/crosstool_wrapper_driver_is_not_gcc:213: SyntaxWarning: invalid escape sequence '\.'
  re.search('\.cpp$|\.cc$|\.c$|\.cxx$|\.C$', f)]
```