### PR TITLE
Prefer prefix includes before system includes.

### DIFF
--- a/recipe/bazel_toolchain/cc_toolchain_config.bzl
+++ b/recipe/bazel_toolchain/cc_toolchain_config.bzl
@@ -150,6 +150,8 @@ def _impl(ctx):
     if "TARGET_PLATFORM".startswith("osx"):
         toolchain_include_directories_flags = [
             "-isystem",
+            "${PREFIX}/include",
+            "-isystem",
             "${CONDA_PREFIX}/include/c++/v1",
             "-isystem",
             "${CONDA_PREFIX}/lib/clang/${COMPILER_VERSION}/include",
@@ -157,8 +159,6 @@ def _impl(ctx):
             "${CONDA_BUILD_SYSROOT}/usr/include",
             "-isystem",
             "${CONDA_BUILD_SYSROOT}/System/Library/Frameworks",
-            "-isystem",
-            "${PREFIX}/include",
         ]
     else:
         toolchain_include_directories_flags = [

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "bazel-toolchain" %}
-{% set version = "0.3.1" %}
+{% set version = "0.3.2" %}
 
 
 package:


### PR DESCRIPTION
Give prefix the precedent for includes before the system includes. 

MacOSX12.1.sdk now contains an old version of the ICU headers (`include/unicode`). By default, these will get used before the conda headers. Leading to errors such as:

```
tensorflow/core/kernels/unicode_script_op.cc:37:20: error: use of undeclared identifier 'status'; did you mean 'std::filesystem::status'?
   37 |     icu::ErrorCode status;
      |                    ^~~~~~
      |                    std::filesystem::status
/Users/lundby/anaconda/aggregate/tensor-testing-vendor-icu2/tensorflow-split_1758213981344/_build_env/include/c++/v1/__filesystem/operations.h:186:42: note: 'std::filesystem::status' declared here
  186 | inline _LIBCPP_HIDE_FROM_ABI file_status status(const path& __p) { return __status(__p); }

```